### PR TITLE
Change taskname from modulus-deploy to modulusDeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ This plugin requires you add environment variables to authenticate with modulus.
 ###MODULUS_TOKEN
  - The API Token that gives access to deploy to the specified project. Please see here for documentation on [how to create an API Token](https://modulus.io/codex/cli/using_api_tokens).
 
-## The "modulus-deploy" task
+## The "modulusDeploy" task
 
 ### Overview
-In your project's Gruntfile, add a section named `modulus-deploy` to the data object passed into `grunt.initConfig()`.
+In your project's Gruntfile, add a section named `modulusDeploy` to the data object passed into `grunt.initConfig()`.
 
 ```js
 grunt.initConfig({
-  modulus-deploy: {
+  modulusDeploy: {
     options: {
       // Task-specific options go here.
     },
@@ -56,7 +56,7 @@ In this example, a target `stage` is defined. When the task runs, it attempts to
 
 ```js
 grunt.initConfig({
-  modulus-deploy: {
+  modulusDeploy: {
     stage: {
       options: {
       	project: "my-site-stage"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Type: `String`
 
 The name of the modulus project to deploy.
 
+#### options.path
+Type: `String`
+
+The relative or absolute path of the folder to deploy.
+
 ### Usage Examples
 
 #### Default Options

--- a/tasks/modulus-deploy.js
+++ b/tasks/modulus-deploy.js
@@ -44,8 +44,13 @@ module.exports = function(grunt) {
         var options = this.options();
 
         var done = this.async();
-
-        var deployCmd = modulusPath + ' deploy' + ' -p ' + options.project;
+        if ( options.path && options.path.length > 0 ) {
+            options.path = ' ' + options.path;
+        } else {
+            options.path = '';
+        }
+        
+        var deployCmd = modulusPath + ' deploy' + ' -p ' + options.project + options.path;
 
         runCmd(deployCmd, options.project+' running at', function(err){
             if(err){

--- a/tasks/modulus-deploy.js
+++ b/tasks/modulus-deploy.js
@@ -40,7 +40,7 @@ var captureOutput = function(child, output) {
 
 module.exports = function(grunt) {
 
-    grunt.registerMultiTask('modulus-deploy', 'Allows deployment to modulus.io from Grunt.', function() {
+    grunt.registerMultiTask('modulusDeploy', 'Allows deployment to modulus.io from Grunt.', function() {
         var options = this.options();
 
         var done = this.async();


### PR DESCRIPTION
I'm SO accustomed to just using proper JS object names, that I'd completely forgotten that I could qualify the names with quotes in this context (I only do that in JSON) and your README.md didn't (so it's using an invalid JS object name). So, here's a PR to update the project to use a valid js object name.

Thanks for the plugin!
